### PR TITLE
jun1/haskell: fix: `where` is a clause, not an expression

### DIFF
--- a/backend/junior-1/haskell.md
+++ b/backend/junior-1/haskell.md
@@ -9,7 +9,7 @@ This level requires basic skills to solve local tasks in a project.
 * Is it possible to declare a function without specifying its type signature?
   Can it cause problems, and if so, which ones?
 * How and when the `let... in...`  expression is used?
-* How and when the `where...`  expression is used?
+* How and when the `where...` clause is used?
 * Function application:
   * What is function application operator? And what is its precedence value?
   * What is partial application?


### PR DESCRIPTION
`Where` is a part of a declaration, not an expression, since it cannot be
reduced to a value.

E.g. see Haskell Report 2010, 4.5 Static Semantics of Function and Pattern
Bindings, p.53:

> The static semantics of the function and pattern bindings of a let expression
> or where clause are discussed in this section.