### PR TITLE
jun2/html: Make tabindex question as independent

### DIFF
--- a/frontend/junior-2/html.md
+++ b/frontend/junior-2/html.md
@@ -8,6 +8,7 @@
   * Какие есть use cases общения родителя и iframe, какие есть способы реализации этого?
   * Что такое кросс-доменные iframes и какие у них ограничения?
 * Что делают `async`, `defer` у скриптов и какая между ними разница?
+* Что делает атрибут `tabindex`? Какие особенности имеет?
 * Рассказать про атрибуты `<form>`:
   * `action`
   * `autocomplete`
@@ -23,7 +24,6 @@
   * `placeholder`
   * `readonly`
   * `required`
-  * `tabindex`
   * `value`
   * `type`
 * Тег `<textarea>`
@@ -36,3 +36,4 @@
 ### Ресурсы
 
 * [HTML5 Video Events and API demo](https://www.w3.org/2010/05/video/mediaevents.html)
+* [Атрибут tabindex](https://learn.javascript.ru/focus-blur#vklyuchaem-fokusirovku-na-lyubom-elemente-tabindex)


### PR DESCRIPTION
Предлагаю сделать вопрос про атрибут [tabindex](https://developer.mozilla.org/ru/docs/Web/HTML/Global_attributes/tabindex) самостоятельным вопросом. Данный атрибут является глобальным, а в контексте вопроса про атрибуты input'a складывается впечатление, что с input'ом он будет вести себя как-то иначе чем с другими тэгами. 