### PR TITLE
haskell: added resource on transformer stacking order

### DIFF
--- a/backend/junior-1/haskell.md
+++ b/backend/junior-1/haskell.md
@@ -239,3 +239,4 @@ This level requires basic skills to solve local tasks in a project.
 #### Resources
 
 * [A curious associativity of the `<$>` operator](https://ro-che.info/articles/2019-07-22-associativity-of-fmap)
+* [Real World Haskell - `Transformer stacking order is important` section](http://book.realworldhaskell.org/read/monad-transformers.html)


### PR DESCRIPTION
Добавил источник с описанием почему важен порядок трансформеров в стеке.