### PR TITLE
jun3/ts: improve formatting

### DIFF
--- a/frontend/junior-3/ts.md
+++ b/frontend/junior-3/ts.md
@@ -39,10 +39,11 @@
 
       // Example:
       const personalInformation: IPersonalInformation = {
-       age: 25,
-       name: 'NameOfAvenger',
-       superpower: 'SuperpowerOfAvenger'
+        age: 25,
+        name: 'NameOfAvenger',
+        superpower: 'SuperpowerOfAvenger'
       };
+
       const survivedAvengers: SurvivedAvengers<'Thor' | 'Hawkeye' | 'Iron Man'> = { 
         Thor: personalInformation, 
         Hawkeye: personalInformation, 


### PR DESCRIPTION
Подправил форматирование в топике frontend/junior-3/ts. Сделал отступ в два символа вместо одного у свойств объекта personalInformation, как у объекта survivedAvengers. Добавил отступ между объектами personalInformation и survivedAvengers для более удобной читаемости.